### PR TITLE
Fix: Remove misleading sandbox display when using --dangerously-bypass-approvals-and-sandbox

### DIFF
--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -67,8 +67,10 @@ impl Display for EnvironmentContext {
             self.cwd.to_string_lossy()
         )?;
         writeln!(f, "Approval policy: {}", self.approval_policy)?;
-        writeln!(f, "Sandbox mode: {}", self.sandbox_mode)?;
-        writeln!(f, "Network access: {}", self.network_access)?;
+        if self.sandbox_mode != SandboxMode::DangerFullAccess {
+            writeln!(f, "Sandbox mode: {}", self.sandbox_mode)?;
+            writeln!(f, "Network access: {}", self.network_access)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes a bug where the environment context incorrectly displays sandbox and network access information when the `--dangerously-bypass-approvals-and-sandbox` flag is used, causing user confusion about the actual security state.

## Problem

When using `--dangerously-bypass-approvals-and-sandbox`, the system currently displays:
```
Sandbox mode: danger-full-access
Network access: enabled
```

This is misleading and causes confusion because:

1. **It suggests sandbox restrictions are still active** - The display of "Sandbox mode: danger-full-access" implies there's still some form of sandbox mode, when in reality all sandbox restrictions are bypassed.

2. **Network access display is misleading** - Showing "Network access: enabled" is particularly confusing because according to the agent harness documentation, network access still requires explicit user approval based on the approval policy, even when using the dangerous flag. 

3. **Real user confusion** - Users have reported confusion when they see "Network access: enabled" but then get refused when requesting network operations without explicit approval. The display contradicts the actual behavior.

## Evidence of Confusion

The attached screenshot from a user demonstrates this confusion clearly:
- User asked for explicit approval for network calls
- Was refused because of the approval policy  
- Yet the system shows "Network access: enabled"
- User had to reference the agent harness documentation to understand the actual behavior

![User confusion about network access display](/var/folders/xf/h7wxvg0937s5kz7r8r4ls66h0000gn/T/c3ba27ba-78fa-4d1f-8c81-2088a42f4c3d/image.png)

## Solution

This fix modifies the `Display` implementation for `EnvironmentContext` to conditionally hide both the "Sandbox mode" and "Network access" lines when `sandbox_mode == SandboxMode::DangerFullAccess`.

### Why hide both lines?

- **Sandbox mode**: When the sandbox is completely bypassed with the dangerous flag, showing any "mode" is misleading
- **Network access**: The "enabled" status is incorrect as network operations still require approval based on the approval policy

By removing these lines when using `--dangerously-bypass-approvals-and-sandbox`, we:
1. Eliminate the confusion about what security restrictions are actually in place
2. Make it clear that the dangerous flag bypasses sandbox (not sets it to a different mode)
3. Avoid misleading users about network access permissions

## Testing

- Added comprehensive tests that verify the correct behavior:
  - `test_environment_context_display_with_danger_full_access`: Verifies sandbox info is hidden when using the dangerous flag
  - `test_environment_context_display_with_sandbox_enabled`: Verifies sandbox info is shown when sandbox is actually active
- Tests fail without the fix and pass with it

## Commits

1. First commit adds failing tests that demonstrate the bug
2. Second commit implements the fix

This structure makes it easy to verify the problem and solution independently.

🤖 Generated with [Claude Code](https://claude.ai/code)